### PR TITLE
[FEAT] 청년층 사연 작성하는 기능 구현

### DIFF
--- a/src/app/latte-chat/letters/new/LetterWriteContainer.tsx
+++ b/src/app/latte-chat/letters/new/LetterWriteContainer.tsx
@@ -4,13 +4,24 @@ import LetterVisibilityToggleContainer from '@/features/letter/create/containers
 import ModalLayout from '@/shared/components/ModalLayout'
 import TitleHeader from '@/shared/components/TitleHeader'
 import Image from 'next/image'
+import useSaveLetter from '@/features/letter/hooks/saveLetter'
 import { useState } from 'react'
+import {
+  useLetterCreateState,
+  useLetterCreateStore,
+} from '@/features/letter/stores/letterCreateStore'
+import { useUserInfo } from '@/shared/hooks/useUserInfo'
 
 export default function LetterWriteContainer() {
+  const { data: userInfo } = useUserInfo() // 추후 여기서 juniorId 추출해서 API에 적용
+
   const [isModalOpen, setIsModalOpen] = useState(false)
   const [isEditorFocus, setIsEditorFocus] = useState(false)
 
-  const [selectedCategory, setSelectedCategory] = useState<string | null>(null)
+  const category = useLetterCreateStore((state) => state.category)
+  const setCategory = useLetterCreateStore((state) => state.setCategory)
+  const letterCreateState = useLetterCreateState()
+  const { mutate: saveLetterMutate } = useSaveLetter()
 
   const handleOpenModal = () => {
     setIsModalOpen(true)
@@ -21,7 +32,7 @@ export default function LetterWriteContainer() {
   }
 
   const handleSelectCategory = (category: string) => {
-    setSelectedCategory(category)
+    setCategory(category)
     handleCloseModal()
   }
 
@@ -46,10 +57,10 @@ export default function LetterWriteContainer() {
               type="button"
               className="h4 flex items-center gap-3 rounded-10 bg-white px-3 py-2"
             >
-              오늘의 주제는...
-              {selectedCategory && (
+              오늘의 주제는
+              {category && (
                 <span className="b4 inline-block rounded-10 border-2 px-4 py-[0.375rem] shadow">
-                  {selectedCategory}
+                  {category}
                 </span>
               )}
               <img
@@ -79,17 +90,22 @@ export default function LetterWriteContainer() {
           </div>
 
           <div
-            className={`${selectedCategory ? 'items-start' : 'items-center'} relative flex w-full flex-1 flex-col overflow-hidden rounded-t-[1.25rem] bg-white`}
+            className={`${category ? 'items-start' : 'items-center'} relative flex w-full flex-1 flex-col overflow-hidden rounded-t-[1.25rem] bg-white`}
           >
             {isEditorFocus ? (
               <div className="h-full w-full flex-1 pt-5">
-                {selectedCategory && (
+                {category && (
                   <span className="b9 mb-4 ml-5 inline-block rounded-md bg-gray-300 px-2 py-[1px] text-white">
                     취업 및 회사
                   </span>
                 )}
                 <Editor />
-                <button className="b3 absolute bottom-5 left-1/2 -translate-x-1/2 rounded-10 bg-gray-500 px-7 py-2 text-white shadow">
+                <button
+                  className="b3 absolute bottom-5 left-1/2 -translate-x-1/2 rounded-10 bg-gray-500 px-7 py-2 text-white shadow"
+                  onClick={() =>
+                    saveLetterMutate({ juniorId: 7, body: letterCreateState })
+                  }
+                >
                   저장하기
                 </button>
               </div>
@@ -101,7 +117,12 @@ export default function LetterWriteContainer() {
                 <p className="b12 text-gray-500">
                   카테고리 선택 후, 오늘의 사연을 작성해보세요
                 </p>
-                <button className="b3 absolute bottom-5 rounded-10 bg-gray-500 px-7 py-2 text-white shadow">
+                <button
+                  className="b3 absolute bottom-5 rounded-10 bg-gray-500 px-7 py-2 text-white shadow"
+                  onClick={() =>
+                    saveLetterMutate({ juniorId: 7, body: letterCreateState })
+                  }
+                >
                   저장하기
                 </button>
               </div>

--- a/src/features/letter/create/components/Editor/index.tsx
+++ b/src/features/letter/create/components/Editor/index.tsx
@@ -1,9 +1,13 @@
-import { useState, useRef } from 'react'
+import { useRef } from 'react'
 import AutoResizeTextarea from '@/shared/components/AutoResizeTextarea'
+import { useLetterCreateStore } from '@/features/letter/stores/letterCreateStore'
 
 export default function Editor() {
-  const [title, setTitle] = useState('')
-  const [content, setContent] = useState('')
+  const title = useLetterCreateStore((state) => state.title)
+  const content = useLetterCreateStore((state) => state.content)
+  const setTitle = useLetterCreateStore((state) => state.setTitle)
+  const setContent = useLetterCreateStore((state) => state.setContent)
+
   const contentRef = useRef<HTMLTextAreaElement>(null)
   const titleRef = useRef<HTMLTextAreaElement>(null)
 

--- a/src/features/letter/create/containers/LetterVisibilityToggleContainer/index.tsx
+++ b/src/features/letter/create/containers/LetterVisibilityToggleContainer/index.tsx
@@ -1,12 +1,12 @@
+import { useLetterCreateStore } from '@/features/letter/stores/letterCreateStore'
 import Toggle from '@/shared/components/Toggle'
-import { useState } from 'react'
 
 export default function LetterVisibilityToggleContainer() {
-  // 사연 공개 여부 상태값 관리
-  const [isChecked, setIsChecked] = useState(false)
+  const isOpen = useLetterCreateStore((state) => state.isOpen)
+  const setIsOpen = useLetterCreateStore((state) => state.setIsOpen)
 
   const handleToggle = () => {
-    setIsChecked(!isChecked)
+    setIsOpen(!isOpen)
   }
 
   return (
@@ -15,7 +15,7 @@ export default function LetterVisibilityToggleContainer() {
       onLabel="게시글 공개"
       width={'6.5rem'}
       onClick={handleToggle}
-      isChecked={isChecked}
+      isChecked={isOpen}
     />
   )
 }

--- a/src/features/letter/hooks/saveLetter.ts
+++ b/src/features/letter/hooks/saveLetter.ts
@@ -1,0 +1,29 @@
+import { useMutation } from '@tanstack/react-query'
+import { useRouter } from 'next/navigation'
+import { saveLetter } from '../services/letterService.client'
+
+export default function useSaveLetter() {
+  const router = useRouter()
+
+  return useMutation({
+    mutationFn: ({
+      juniorId,
+      body,
+    }: {
+      juniorId: number
+      body: {
+        category: string | null
+        title: string
+        content: string
+        isOpen: boolean
+      }
+    }) => saveLetter({ juniorId }, body),
+    onSuccess: (data) => {
+      console.log('사연 등록 성공:', data)
+      router.back()
+    },
+    onError: (error) => {
+      console.error('사연 등록 실패:', error)
+    },
+  })
+}

--- a/src/features/letter/services/letterService.client.ts
+++ b/src/features/letter/services/letterService.client.ts
@@ -1,0 +1,25 @@
+'use client'
+
+import { httpCSR } from '@/shared/apis/http'
+
+// 청년층 사연 작성
+export const saveLetter = async (
+  { juniorId }: { juniorId: number },
+  body: {
+    category: string | null
+    title: string
+    content: string
+    isOpen: boolean
+  }
+) => {
+  const token = localStorage.getItem('accessToken')
+  if (!token) throw new Error('토큰이 없습니다.')
+
+  return await httpCSR(`/junior/${juniorId}/letter/post`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify(body),
+  })
+}

--- a/src/features/letter/stores/letterCreateStore.ts
+++ b/src/features/letter/stores/letterCreateStore.ts
@@ -1,0 +1,55 @@
+import { create } from 'zustand'
+import { persist } from 'zustand/middleware'
+
+type LetterCreateState = {
+  category: string | null
+  title: string
+  content: string
+  isOpen: boolean
+}
+
+type LetterCreateActions = {
+  setCategory: (name: string) => void
+  setTitle: (title: string) => void
+  setContent: (content: string) => void
+  setIsOpen: (isOpen: boolean) => void
+  reset: () => void
+}
+
+const initialState: LetterCreateState = {
+  category: null,
+  title: '',
+  content: '',
+  isOpen: false,
+}
+
+export const useLetterCreateStore = create<
+  LetterCreateState & LetterCreateActions
+>()(
+  persist(
+    (set) => ({
+      ...initialState,
+      setCategory: (category) => set({ category }),
+      setTitle: (title) => set({ title }),
+      setContent: (content) => set({ content }),
+      setIsOpen: (isOpen) => set({ isOpen }),
+      reset: () => set({ ...initialState }),
+    }),
+    { name: 'letter-create-storage' }
+  )
+)
+
+export const useLetterCreateState = () => ({
+  category: useLetterCreateStore((s) => s.category),
+  title: useLetterCreateStore((s) => s.title),
+  content: useLetterCreateStore((s) => s.content),
+  isOpen: useLetterCreateStore((s) => s.isOpen),
+})
+
+export const useLetterCreateActions = () => ({
+  setCategory: useLetterCreateStore((s) => s.setCategory),
+  setTitle: useLetterCreateStore((s) => s.setTitle),
+  setContent: useLetterCreateStore((s) => s.setContent),
+  setIsOpen: useLetterCreateStore((s) => s.setIsOpen),
+  reset: useLetterCreateStore((s) => s.reset),
+})


### PR DESCRIPTION
## ✨ 개요

청년층 사연 작성하는 기능 구현

## 🔨 작업 내용

- [ ] UI 구현
- [ ] 컴포넌트 구현
- [X] API 연동
- [ ] 스타일 수정

## 📝 추가 설명

- 청년층 사연 작성하는 API 연동
- 사연 저장할 때 필요한 값을 전역 상태로 관리
- 작성하는 기능 커스텀훅으로 제작

## 🔗 관련 이슈

Closes #32 
